### PR TITLE
feat(models,seeds): switch Clothing.type to Type ref + add seeds

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -7,7 +7,9 @@
     "dev": "nodemon src/server.js",
     "start": "node src/server.js",
     "seed:types": "node seeds/seed-types.js",
-    "seed:clothes": "node seeds/seed-clothes.js"
+    "seed:clothes": "node seeds/seed-clothes.js",
+    "seed:outfits": "node seeds/seed-outfits.js",
+    "seed:all": "npm run seed:types && npm run seed:clothes && npm run seed:outfits"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/api/seeds/seed-clothes.js
+++ b/api/seeds/seed-clothes.js
@@ -1,18 +1,504 @@
 import "dotenv/config"
 import { connectDB, disconnectDB } from "../src/db/index.js"
+import Type from "../src/models/Type.js"
 import Clothing from "../src/models/Clothing.js"
 
 async function main() {
   await connectDB()
-  console.log("Seeding clothes...")
+  console.log("Seeding: clothes…")
+
+  const allTypes = await Type.find()
+  console.log("Type docs found:", allTypes.length)
+  const typeMap = Object.fromEntries(allTypes.map((t) => [t.name, t._id]))
+  console.log(typeMap)
+
+  const neededTypes = [
+    "Shorts",
+    "Pants",
+    "Skirts",
+    "Tees",
+    "Blouses",
+    "Tanks",
+    "Sweaters",
+    "Dresses",
+    "Jumpsuits",
+    "Overalls",
+    "Sneakers",
+    "Boots",
+    "Shoes",
+    "Sandals",
+    "Hats",
+    "Belts",
+    "Coats",
+    "Jackets",
+    "Gloves",
+    "Vests"
+  ]
+  const missing = neededTypes.filter((n) => !typeMap[n])
+
+  if (missing.length) {
+    console.error("Missing Type(s):", missing)
+    console.error("Available Type names:", allTypes.map((t) => t.name).sort())
+    process.exit(1)
+  }
 
   await Clothing.deleteMany({})
-
   const clothes = await Clothing.insertMany([
+    {
+      name: "Orange drawstring shorts",
+      type: typeMap["Shorts"],
+      imageUrl: "/placeholder-img.jpg",
+      subtype: "Bermuda",
+      colors: ["Orange"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 5,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Light wash jean shorts",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Shorts"],
+      subtype: "Denim",
+      colors: ["Blue"],
+      size: "S",
+      ratings: {
+        comfort: 2,
+        confidence: 4,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Blue running shorts",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Shorts"],
+      subtype: "Athletic",
+      colors: ["Blue"],
+      size: "M",
+      ratings: {
+        comfort: 3,
+        confidence: 5,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Black spandex shorts",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Shorts"],
+      subtype: "Spandex",
+      colors: ["Black"],
+      size: "S",
+      ratings: {
+        comfort: 4,
+        confidence: 5,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Low-rise blue shorts",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Shorts"],
+      subtype: "Low-rise",
+      colors: ["Blue"],
+      size: "S",
+      ratings: {
+        comfort: 2,
+        confidence: 3,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "High-waisted white shorts",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Shorts"],
+      subtype: "High-waisted",
+      colors: ["White"],
+      size: "M",
+      ratings: {
+        comfort: 3,
+        confidence: 4,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Blue jeans",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Pants"],
+      subtype: "Jeans",
+      colors: ["Blue"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 2,
+        warmth: 3
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Khaki chinos",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Pants"],
+      subtype: "Chinos",
+      colors: ["Khaki"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 3,
+        warmth: 3
+      },
+      waterproof: false,
+      workAppropriate: true
+    },
+    {
+      name: "Olive cargo pants",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Pants"],
+      subtype: "Cargo",
+      colors: ["Olive"],
+      size: "L",
+      ratings: {
+        comfort: 2,
+        confidence: 5,
+        warmth: 3
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Grey joggers",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Pants"],
+      subtype: "Joggers",
+      colors: ["Grey"],
+      size: "L",
+      ratings: {
+        comfort: 5,
+        confidence: 4,
+        warmth: 3
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Grey leggings",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Pants"],
+      subtype: "Leggings",
+      colors: ["Grey"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 3,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Pink mini skirt",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Skirts"],
+      subtype: "Mini",
+      colors: ["Pink"],
+      size: "S",
+      ratings: {
+        comfort: 3,
+        confidence: 3,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Black tennis skirt",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Skirts"],
+      subtype: "Tennis",
+      colors: ["Black"],
+      size: "S",
+      ratings: {
+        comfort: 4,
+        confidence: 3,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Brown maxi skirt",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Skirts"],
+      subtype: "Maxi",
+      colors: ["Brown"],
+      size: "M",
+      ratings: {
+        comfort: 3,
+        confidence: 4,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: true
+    },
+    {
+      name: "Blue A-line skirt",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Skirts"],
+      subtype: "A-line",
+      colors: ["Blue"],
+      size: "M",
+      ratings: {
+        comfort: 3,
+        confidence: 4,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: true
+    },
+    {
+      name: "Yellow skort",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Skirts"],
+      subtype: "Skort",
+      colors: ["Yellow"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 4,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "White graphic tee",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Tees"],
+      subtype: "Graphic",
+      colors: ["White"],
+      size: "M",
+      ratings: {
+        comfort: 2,
+        confidence: 4,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Red v-neck tee",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Tees"],
+      subtype: "V-neck",
+      colors: ["Red"],
+      size: "M",
+      ratings: {
+        comfort: 5,
+        confidence: 4,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Teal crewneck tee",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Tees"],
+      subtype: "Crewneck",
+      colors: ["Teal"],
+      size: "M",
+      ratings: {
+        comfort: 5,
+        confidence: 4,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Blue long sleeve tee",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Tees"],
+      subtype: "Long sleeve",
+      colors: ["Blue"],
+      size: "M",
+      ratings: {
+        comfort: 5,
+        confidence: 4,
+        warmth: 3
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "White button-down blouse",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Blouses"],
+      subtype: "Button-down",
+      colors: ["White"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 5,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: true
+    },
+    {
+      name: "Purple peplum blouse",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Blouses"],
+      subtype: "Peplum",
+      colors: ["Purple"],
+      size: "M",
+      ratings: {
+        comfort: 1,
+        confidence: 3,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Mauve wrap blouse",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Blouses"],
+      subtype: "Wrap",
+      colors: ["Mauve"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 3,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: true
+    },
+    {
+      name: "Pink sleeveless blouse",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Blouses"],
+      subtype: "Sleeveless",
+      colors: ["Pink"],
+      size: "M",
+      ratings: {
+        comfort: 2,
+        confidence: 4,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Red halter tank",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Tanks"],
+      subtype: "Halter",
+      colors: ["Red"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 4,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Black racerback tank",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Tanks"],
+      subtype: "Racerback",
+      colors: ["Black"],
+      size: "M",
+      ratings: {
+        comfort: 3,
+        confidence: 5,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Taupe muscle tank",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Tanks"],
+      subtype: "Muscle",
+      colors: ["Taupe"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 3,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Black spaghetti strap tank",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Tanks"],
+      subtype: "Spaghetti strap",
+      colors: ["Black"],
+      size: "S",
+      ratings: {
+        comfort: 5,
+        confidence: 4,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Rainbow cardigan sweater",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Sweaters"],
+      subtype: "Cardigan",
+      colors: ["Rainbow"],
+      size: "M",
+      ratings: {
+        comfort: 5,
+        confidence: 4,
+        warmth: 3
+      },
+      waterproof: false,
+      workAppropriate: true
+    },
+
+    {
+      name: "Teal pullover sweater",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Sweaters"],
+      subtype: "Pullover",
+      colors: ["Teal"],
+      size: "M",
+      ratings: {
+        comfort: 5,
+        confidence: 5,
+        warmth: 3
+      },
+      waterproof: false,
+      workAppropriate: true
+    },
     {
       name: "Cream turtleneck sweater",
       imageUrl: "/placeholder-img.jpg",
-      type: "Sweaters",
+      type: typeMap["Sweaters"],
       subtype: "Turtleneck",
       colors: ["Cream"],
       size: "M",
@@ -25,14 +511,29 @@ async function main() {
       workAppropriate: true
     },
     {
-      name: "Green baseball hat",
+      name: "Grey crewneck sweater",
       imageUrl: "/placeholder-img.jpg",
-      type: "Hats",
-      subtype: "Baseball",
-      colors: ["Green"],
+      type: typeMap["Sweaters"],
+      subtype: "Crewneck",
+      colors: ["Grey"],
       size: "M",
       ratings: {
-        comfort: 5,
+        comfort: 4,
+        confidence: 4,
+        warmth: 3
+      },
+      waterproof: false,
+      workAppropriate: true
+    },
+    {
+      name: "Burgundy shift dress",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Dresses"],
+      subtype: "Shift",
+      colors: ["Burgundy"],
+      size: "M",
+      ratings: {
+        comfort: 2,
         confidence: 4,
         warmth: 1
       },
@@ -40,9 +541,144 @@ async function main() {
       workAppropriate: false
     },
     {
+      name: "Little black dress",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Dresses"],
+      subtype: "Little black",
+      colors: ["Black"],
+      size: "S",
+      ratings: {
+        comfort: 5,
+        confidence: 3,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "White slip dress",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Dresses"],
+      subtype: "Slip",
+      colors: ["White"],
+      size: "M",
+      ratings: {
+        comfort: 3,
+        confidence: 5,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Turquoise bodycon dress",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Dresses"],
+      subtype: "Bodycon",
+      colors: ["Turquoise"],
+      size: "S",
+      ratings: {
+        comfort: 3,
+        confidence: 5,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Blush ruffle dress",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Dresses"],
+      subtype: "Ruffle",
+      colors: ["Blush"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 3,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Navy romper jumpsuit",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Jumpsuits"],
+      subtype: "Romper",
+      colors: ["Navy"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 3,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Black wide leg jumpsuit",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Jumpsuits"],
+      subtype: "Wide leg",
+      colors: ["Black"],
+      size: "M",
+      ratings: {
+        comfort: 5,
+        confidence: 5,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Marine professional jumpsuit",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Jumpsuits"],
+      subtype: "Professional",
+      colors: ["Marine"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 4,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: true
+    },
+    {
+      name: "Forest green utility jumpsuit",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Jumpsuits"],
+      subtype: "Utility",
+      colors: ["Forest green"],
+      size: "M",
+      ratings: {
+        comfort: 5,
+        confidence: 5,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Denim overalls",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Overalls"],
+      subtype: "Denim",
+      colors: ["Blue"],
+      size: "M",
+      ratings: {
+        comfort: 5,
+        confidence: 4,
+        warmth: 3
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
       name: "Camel corduroy overalls",
       imageUrl: "/placeholder-img.jpg",
-      type: "Overalls",
+      type: typeMap["Overalls"],
       subtype: "Corduroy",
       colors: ["Camel"],
       size: "M",
@@ -55,9 +691,144 @@ async function main() {
       workAppropriate: false
     },
     {
+      name: "Black shortalls",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Overalls"],
+      subtype: "Shortalls",
+      colors: ["Black"],
+      size: "S",
+      ratings: {
+        comfort: 4,
+        confidence: 3,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "White low-top sneakers",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Sneakers"],
+      subtype: "Low-top",
+      colors: ["White"],
+      size: "8",
+      ratings: {
+        comfort: 2,
+        confidence: 4,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "White high-top sneakers",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Sneakers"],
+      subtype: "High-top",
+      colors: ["White"],
+      size: "8",
+      ratings: {
+        comfort: 3,
+        confidence: 5,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Red slip-on sneakers",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Sneakers"],
+      subtype: "Slip-on",
+      colors: ["Red"],
+      size: "8",
+      ratings: {
+        comfort: 4,
+        confidence: 5,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Grey running sneakers",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Sneakers"],
+      subtype: "Running",
+      colors: ["Grey"],
+      size: "8",
+      ratings: {
+        comfort: 5,
+        confidence: 2,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Brown cowboy boots",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Boots"],
+      subtype: "Cowboy",
+      colors: ["Brown"],
+      size: "8",
+      ratings: {
+        comfort: 3,
+        confidence: 3,
+        warmth: 2
+      },
+      waterproof: true,
+      workAppropriate: false
+    },
+    {
+      name: "Black knee-high boots",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Boots"],
+      subtype: "Knee-high",
+      colors: ["Black"],
+      size: "8",
+      ratings: {
+        comfort: 3,
+        confidence: 4,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Tan steel-toed boots",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Boots"],
+      subtype: "Steel-toed",
+      colors: ["Tan"],
+      size: "8",
+      ratings: {
+        comfort: 4,
+        confidence: 3,
+        warmth: 2
+      },
+      waterproof: true,
+      workAppropriate: true
+    },
+    {
+      name: "Blue snow boots",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Boots"],
+      subtype: "Snow",
+      colors: ["Blue"],
+      size: "8",
+      ratings: {
+        comfort: 3,
+        confidence: 3,
+        warmth: 5
+      },
+      waterproof: true,
+      workAppropriate: false
+    },
+    {
       name: "Grey oxfords",
       imageUrl: "/placeholder-img.jpg",
-      type: "Specialty Shoes",
+      type: typeMap["Shoes"],
       subtype: "Oxfords",
       colors: ["Grey"],
       size: "8",
@@ -68,15 +839,494 @@ async function main() {
       },
       waterproof: false,
       workAppropriate: true
+    },
+    {
+      name: "Blush heels",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Shoes"],
+      subtype: "Heels",
+      colors: ["Blush"],
+      size: "8",
+      ratings: {
+        comfort: 5,
+        confidence: 4,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Hot pink platforms",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Shoes"],
+      subtype: "Platforms",
+      colors: ["Hot pink"],
+      size: "8",
+      ratings: {
+        comfort: 4,
+        confidence: 4,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Red crocs",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Shoes"],
+      subtype: "Crocs",
+      colors: ["Red"],
+      size: "8",
+      ratings: {
+        comfort: 3,
+        confidence: 3,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Tan birks",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Sandals"],
+      subtype: "Birks",
+      colors: ["Tan"],
+      size: "8",
+      ratings: {
+        comfort: 3,
+        confidence: 3,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Nude espadrilles",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Sandals"],
+      subtype: "Espadrilles",
+      colors: ["Nude"],
+      size: "8",
+      ratings: {
+        comfort: 0,
+        confidence: 2,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Yellow flip-flops",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Sandals"],
+      subtype: "Flip-flops",
+      colors: ["Yellow"],
+      size: "8",
+      ratings: {
+        comfort: 1,
+        confidence: 3,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Charcoal slides",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Sandals"],
+      subtype: "Slides",
+      colors: ["Charcoal"],
+      size: "8",
+      ratings: {
+        comfort: 4,
+        confidence: 3,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Green baseball hat",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Hats"],
+      subtype: "Baseball",
+      colors: ["Green"],
+      size: "M",
+      ratings: {
+        comfort: 5,
+        confidence: 4,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Yellow bucket hat",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Hats"],
+      subtype: "Bucket",
+      colors: ["Yellow"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 1,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Red beanie",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Hats"],
+      subtype: "Beanie",
+      colors: ["Red"],
+      size: "M",
+      ratings: {
+        comfort: 3,
+        confidence: 5,
+        warmth: 3
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Blue visor",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Hats"],
+      subtype: "Visor",
+      colors: ["Blue"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 5,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Black leather belt",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Belts"],
+      subtype: "Leather",
+      colors: ["Black"],
+      size: "M",
+      ratings: {
+        comfort: 0,
+        confidence: 5,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: true
+    },
+    {
+      name: "Off-white canvas belt",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Belts"],
+      subtype: "Canvas",
+      colors: ["Off-white"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 5,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: true
+    },
+    {
+      name: "Tan braided belt",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Belts"],
+      subtype: "Braided",
+      colors: ["Tan"],
+      size: "M",
+      ratings: {
+        comfort: 5,
+        confidence: 3,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: true
+    },
+    {
+      name: "Brown buckled belt",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Belts"],
+      subtype: "Buckled",
+      colors: ["Brown"],
+      size: "M",
+      ratings: {
+        comfort: 3,
+        confidence: 5,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: true
+    },
+    {
+      name: "Nude trench coat",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Coats"],
+      subtype: "Trench",
+      colors: ["Nude"],
+      size: "M",
+      ratings: {
+        comfort: 2,
+        confidence: 4,
+        warmth: 4
+      },
+      waterproof: false,
+      workAppropriate: true
+    },
+    {
+      name: "Black puffer coat",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Coats"],
+      subtype: "Puffer",
+      colors: ["Black"],
+      size: "M",
+      ratings: {
+        comfort: 3,
+        confidence: 3,
+        warmth: 4
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Sage green snow coat",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Coats"],
+      subtype: "Snow",
+      colors: ["Sage green"],
+      size: "M",
+      ratings: {
+        comfort: 3,
+        confidence: 5,
+        warmth: 5
+      },
+      waterproof: true,
+      workAppropriate: false
+    },
+    {
+      name: "Red parka",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Coats"],
+      subtype: "Parka",
+      colors: ["Red"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 4,
+        warmth: 5
+      },
+      waterproof: true,
+      workAppropriate: false
+    },
+    {
+      name: "Brown bomber jacket",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Jackets"],
+      subtype: "Bomber",
+      colors: ["Brown"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 4,
+        warmth: 4
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Brown leather jacket",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Jackets"],
+      subtype: "Leather",
+      colors: ["Brown"],
+      size: "M",
+      ratings: {
+        comfort: 3,
+        confidence: 5,
+        warmth: 4
+      },
+      waterproof: true,
+      workAppropriate: false
+    },
+    {
+      name: "Navy blazer",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Jackets"],
+      subtype: "Blazer",
+      colors: ["Navy"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 4,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: true
+    },
+    {
+      name: "Blue jean jacket",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Jackets"],
+      subtype: "Jean",
+      colors: ["Blue"],
+      size: "M",
+      ratings: {
+        comfort: 3,
+        confidence: 3,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Purple windbreaker",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Jackets"],
+      subtype: "Windbreaker",
+      colors: ["Purple"],
+      size: "M",
+      ratings: {
+        comfort: 5,
+        confidence: 4,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Black leather gloves",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Gloves"],
+      subtype: "Leather",
+      colors: ["Black"],
+      size: "M",
+      ratings: {
+        comfort: 3,
+        confidence: 5,
+        warmth: 3
+      },
+      waterproof: true,
+      workAppropriate: false
+    },
+    {
+      name: "Grey wool gloves",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Gloves"],
+      subtype: "Wool",
+      colors: ["Grey"],
+      size: "M",
+      ratings: {
+        comfort: 5,
+        confidence: 4,
+        warmth: 3
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "White snow gloves",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Gloves"],
+      subtype: "Snow",
+      colors: ["White"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 2,
+        warmth: 5
+      },
+      waterproof: true,
+      workAppropriate: false
+    },
+    {
+      name: "Black work gloves",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Gloves"],
+      subtype: "Work",
+      colors: ["Black"],
+      size: "M",
+      ratings: {
+        comfort: 3,
+        confidence: 3,
+        warmth: 4
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Red puffer vest",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Vests"],
+      subtype: "Puffer",
+      colors: ["Red"],
+      size: "M",
+      ratings: {
+        comfort: 4,
+        confidence: 4,
+        warmth: 2
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "White denim vest",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Vests"],
+      subtype: "Denim",
+      colors: ["White"],
+      size: "M",
+      ratings: {
+        comfort: 5,
+        confidence: 5,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Olive utility vest",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Vests"],
+      subtype: "Utility",
+      colors: ["Olive"],
+      size: "M",
+      ratings: {
+        comfort: 5,
+        confidence: 3,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
+    },
+    {
+      name: "Green quilted vest",
+      imageUrl: "/placeholder-img.jpg",
+      type: typeMap["Vests"],
+      subtype: "Quilted",
+      colors: ["Green"],
+      size: "M",
+      ratings: {
+        comfort: 5,
+        confidence: 3,
+        warmth: 1
+      },
+      waterproof: false,
+      workAppropriate: false
     }
   ])
 
-  console.log(`Added ${clothes.length} clothes documents`)
-
+  console.log(`Clothes inserted: ${clothes.length}`)
   await disconnectDB()
 }
 
-main().catch((err) => {
-  console.error("Clothes seed error:", err)
+main().catch((e) => {
+  console.error("Seed-clothes error:", e)
   process.exit(1)
 })

--- a/api/seeds/seed-outfits.js
+++ b/api/seeds/seed-outfits.js
@@ -1,0 +1,184 @@
+import "dotenv/config"
+import { connectDB, disconnectDB } from "../src/db/index.js"
+import Clothing from "../src/models/Clothing.js"
+import Outfit from "../src/models/Outfit.js"
+
+async function main() {
+  await connectDB()
+  console.log("Seeding: outfits…")
+
+  const allClothes = await Clothing.find()
+  const clothesMap = Object.fromEntries(allClothes.map((c) => [c.name, c._id]))
+
+  const need = (names) => {
+    const ids = names.map((n) => clothesMap[n]).filter(Boolean)
+    const missing = names.filter((n) => !clothesMap[n])
+    if (missing.length)
+      throw new Error(`Missing clothing: ${missing.join(", ")}`)
+    return ids
+  }
+
+  await Outfit.deleteMany({})
+  await Outfit.insertMany([
+    {
+      title: "Campfire Vibes",
+      imageUrl: "/placeholder-img.jpg",
+      occasion: "Outdoor Bonfire",
+      weather: "Starry, Cool, Evening",
+      favorite: true,
+      items: need([
+        "Cream turtleneck sweater",
+        "Green baseball hat",
+        "Camel corduroy overalls",
+        "Grey oxfords"
+      ])
+    },
+    {
+      title: "Beach Day",
+      imageUrl: "/placeholder-img.jpg",
+      occasion: "Swimming at the beach or pool",
+      weather: "Sunny, Warm",
+      favorite: true,
+      items: need([
+        "Yellow bucket hat",
+        "Black spaghetti strap tank",
+        "Yellow flip-flops",
+        "Yellow skort"
+      ])
+    },
+    {
+      title: "Autumn Casual",
+      imageUrl: "/placeholder-img.jpg",
+      occasion: "Casual hanging out, weekend",
+      weather: "Mild",
+      favorite: true,
+      items: need([
+        "White denim vest",
+        "Tan steel-toed boots",
+        "Forest green utility jumpsuit"
+      ])
+    },
+    {
+      title: "Country Look",
+      imageUrl: "/placeholder-img.jpg",
+      occasion: "Weekend at Mom's in the country",
+      weather: "Varied, Cloudy",
+      favorite: true,
+      items: need([
+        "Brown bomber jacket",
+        "Blue jeans",
+        "Brown buckled belt",
+        "Brown cowboy boots",
+        "Blue long sleeve tee"
+      ])
+    },
+    {
+      title: "Formal",
+      imageUrl: "/placeholder-img.jpg",
+      occasion: "Gala, fancy event",
+      weather: "Cool, Indoors",
+      favorite: true,
+      items: need([
+        "Turquoise bodycon dress",
+        "Black knee-high boots",
+        "Black leather belt",
+        "Black leather gloves"
+      ])
+    },
+    {
+      title: "Going Out",
+      imageUrl: "/placeholder-img.jpg",
+      occasion: "Date night, going out, party",
+      weather: "Cool, Evening",
+      favorite: false,
+      items: need(["Burgundy shift dress", "Blush heels", "Nude trench coat"])
+    },
+    {
+      title: "Summer Casual",
+      imageUrl: "/placeholder-img.jpg",
+      occasion: "Summer, vacation, hanging out",
+      weather: "Sunny",
+      favorite: false,
+      items: need([
+        "Blue jean jacket",
+        "Red v-neck tee",
+        "Light wash jean shorts",
+        "White low-top sneakers"
+      ])
+    },
+    {
+      title: "Sporty Look",
+      imageUrl: "/placeholder-img.jpg",
+      occasion: "Jogging, working out at the gym",
+      weather: "Warm",
+      favorite: false,
+      items: need([
+        "White graphic tee",
+        "Blue running shorts",
+        "Grey running sneakers"
+      ])
+    },
+    {
+      title: "Feminine Casual",
+      imageUrl: "/placeholder-img.jpg",
+      occasion: "Picnic in the park, brewery, themepark outing",
+      weather: "Sunny",
+      favorite: false,
+      items: need([
+        "Red halter tank",
+        "Pink mini skirt",
+        "Hot pink platforms",
+        "White button-down blouse"
+      ])
+    },
+    {
+      title: "Snow Day",
+      imageUrl: "/placeholder-img.jpg",
+      occasion: "Winter, snow day in the mountains",
+      weather: "Snowy, Cold",
+      favorite: false,
+      items: need([
+        "Red beanie",
+        "White snow gloves",
+        "Blue snow boots",
+        "Sage green snow coat",
+        "Grey joggers"
+      ])
+    },
+    {
+      title: "Rainy Day",
+      imageUrl: "/placeholder-img.jpg",
+      occasion: "Rainy day, sprinkling, running errands",
+      weather: "Rainy, Cool, Cloudy",
+      favorite: false,
+      items: need([
+        "Blue visor",
+        "Grey crewneck sweater",
+        "Purple windbreaker",
+        "Grey leggings",
+        "White low-top sneakers"
+      ])
+    },
+    {
+      title: "Professional",
+      imageUrl: "/placeholder-img.jpg",
+      occasion: "Work, conference, business casual event",
+      weather: "Mild, Indoors",
+      favorite: false,
+      items: need([
+        "Off-white canvas belt",
+        "Nude espadrilles",
+        "Marine professional jumpsuit",
+        "Navy blazer"
+      ])
+    }
+  ])
+
+  console.log("Outfits inserted: 1")
+  await disconnectDB()
+}
+
+main().catch((e) => {
+  console.error("Seed-outfits error:", e)
+  process.exit(1)
+})

--- a/api/seeds/seed-types.js
+++ b/api/seeds/seed-types.js
@@ -4,51 +4,164 @@ import Type from "../src/models/Type.js"
 
 async function main() {
   await connectDB()
-  console.log("Seeding types...")
+  console.log("Seeding: types…")
 
   await Type.deleteMany({})
-
   const types = await Type.insertMany([
     {
-      type: "Sweaters",
+      name: "Shorts",
+      subtypes: [
+        "Bermuda",
+        "Denim",
+        "Athletic",
+        "Spandex",
+        "High-waisted",
+        "Low-rise"
+      ],
+      drawer: "Bottoms",
+      sufficient: false,
+      necessity: 1
+    },
+    {
+      name: "Pants",
+      subtypes: ["Jeans", "Chinos", "Cargo", "Joggers", "Leggings"],
+      drawer: "Bottoms",
+      sufficient: false,
+      necessity: 1
+    },
+    {
+      name: "Skirts",
+      subtypes: ["Mini", "Tennis", "Maxi", "Skort", "A-line"],
+      drawer: "Bottoms",
+      sufficient: false,
+      necessity: 1
+    },
+    {
+      name: "Tees",
+      subtypes: ["Graphic", "V-neck", "Crewneck", "Long sleeve", "Crop"],
+      drawer: "Tops",
+      sufficient: false,
+      necessity: 1
+    },
+    {
+      name: "Blouses",
+      subtypes: ["Button-down", "Peplum", "Wrap", "Sleeveless", "Ruffle"],
+      drawer: "Tops",
+      sufficient: false,
+      necessity: 1
+    },
+    {
+      name: "Tanks",
+      subtypes: ["Halter", "Racerback", "Muscle", "Spaghetti strap"],
+      drawer: "Tops",
+      sufficient: false,
+      necessity: 1
+    },
+    {
+      name: "Sweaters",
       subtypes: ["Cardigan", "Pullover", "Turtleneck", "Crewneck"],
-      category: "Tops",
+      drawer: "Tops",
       sufficient: false,
-      necessity: 2,
-      clothing: sweaters
+      necessity: 2
     },
     {
-      type: "Hats",
-      subtypes: ["Baseball", "Beanie", "Visor", "Bucket"],
-      category: "Accessories",
-      sufficient: false,
-      necessity: 3,
-      clothing: hats
-    },
-    {
-      type: "Overalls",
-      subtypes: ["Denim", "Corduroy", "Shortalls"],
-      category: "One-pieces",
+      name: "Dresses",
+      subtypes: ["Shift", "Ruffle", "Little black", "Bodycon", "Slip"],
+      drawer: "One-pieces",
       sufficient: true,
-      necessity: 2,
-      clothing: overalls
+      necessity: 1
     },
     {
-      type: "Specialty Shoes",
-      subtypes: ["Crocs", "Platforms", "Heels", "Oxfords"],
-      category: "Shoes",
+      name: "Jumpsuits",
+      subtypes: ["Romper", "Professional", "Utility", "Wide leg"],
+      drawer: "One-pieces",
+      sufficient: true,
+      necessity: 1
+    },
+    {
+      name: "Overalls",
+      subtypes: ["Denim", "Corduroy", "Shortalls"],
+      drawer: "One-pieces",
       sufficient: false,
-      necessity: 1,
-      clothing: specialtyShoes
+      necessity: 1
+    },
+    {
+      name: "Sneakers",
+      subtypes: ["Low-top", "High-top", "Slip-on", "Running"],
+      drawer: "Shoes",
+      sufficient: false,
+      necessity: 1
+    },
+    {
+      name: "Boots",
+      subtypes: ["Snow", "Knee-high", "Steel-toed", "Cowboy"],
+      drawer: "Shoes",
+      sufficient: false,
+      necessity: 1
+    },
+    {
+      name: "Shoes",
+      subtypes: ["Crocs", "Platforms", "Heels", "Oxfords"],
+      drawer: "Shoes",
+      sufficient: false,
+      necessity: 1
+    },
+    {
+      name: "Sandals",
+      subtypes: ["Slides", "Birks", "Flip-flops", "Espadrilles"],
+      drawer: "Shoes",
+      sufficient: false,
+      necessity: 1
+    },
+    {
+      name: "Hats",
+      subtypes: ["Baseball", "Beanie", "Visor", "Bucket"],
+      drawer: "Accessories",
+      sufficient: false,
+      necessity: 3
+    },
+    {
+      name: "Belts",
+      subtypes: ["Leather", "Canvas", "Braided", "Buckled"],
+      drawer: "Accessories",
+      sufficient: false,
+      necessity: 3
+    },
+    {
+      name: "Coats",
+      subtypes: ["Trench", "Puffer", "Peacoat", "Parka", "Snow"],
+      drawer: "Outerwear",
+      sufficient: false,
+      necessity: 3
+    },
+    {
+      name: "Jackets",
+      subtypes: ["Bomber", "Jean", "Blazer", "Windbreaker", "Leather"],
+      drawer: "Outerwear",
+      sufficient: false,
+      necessity: 3
+    },
+    {
+      name: "Gloves",
+      subtypes: ["Leather", "Wool", "Work", "Snow"],
+      drawer: "Outerwear",
+      sufficient: false,
+      necessity: 3
+    },
+    {
+      name: "Vests",
+      subtypes: ["Puffer", "Denim", "Utility", "Quilted"],
+      drawer: "Outerwear",
+      sufficient: false,
+      necessity: 3
     }
   ])
 
-  console.log(`Added ${types.length} types documents`)
-
+  console.log(`Types inserted: ${types.length}`)
   await disconnectDB()
 }
 
-main().catch((err) => {
-  console.error("Types seed error:", err)
+main().catch((e) => {
+  console.error("Seed-types error:", e)
   process.exit(1)
 })

--- a/api/src/controllers/clothingController.js
+++ b/api/src/controllers/clothingController.js
@@ -2,7 +2,7 @@ import Clothing from "../models/Clothing.js"
 
 export async function getAllClothes(_req, res, next) {
   try {
-    const docs = await Clothing.find()
+    const docs = await Clothing.find().populate("type")
     res.json(docs)
   } catch (err) {
     next(err)

--- a/api/src/models/Clothing.js
+++ b/api/src/models/Clothing.js
@@ -3,8 +3,8 @@ import mongoose from "mongoose"
 const ClothingSchema = new mongoose.Schema(
   {
     name: { type: String, required: true },
+    type: { type: mongoose.Schema.Types.ObjectId, ref: "Type", required: true },
     imageUrl: { type: String, required: true },
-    type: { type: String, required: true },
     subtype: { type: String, required: true },
     colors: [{ type: String, required: true }],
     size: { type: String, required: false },

--- a/api/src/models/Clothing.js
+++ b/api/src/models/Clothing.js
@@ -4,17 +4,17 @@ const ClothingSchema = new mongoose.Schema(
   {
     name: { type: String, required: true },
     type: { type: mongoose.Schema.Types.ObjectId, ref: "Type", required: true },
-    imageUrl: { type: String, required: true },
-    subtype: { type: String, required: true },
-    colors: [{ type: String, required: true }],
-    size: { type: String, required: false },
+    imageUrl: { type: String },
+    subtype: { type: String },
+    colors: [{ type: String }],
+    size: { type: String },
     ratings: {
-      comfort: { type: Number, required: true, min: 0, max: 5 },
-      confidence: { type: Number, required: true, min: 0, max: 5 },
-      warmth: { type: Number, required: true, min: 0, max: 5 }
+      comfort: { type: Number, min: 0, max: 5 },
+      confidence: { type: Number, min: 0, max: 5 },
+      warmth: { type: Number, min: 0, max: 5 }
     },
-    waterproof: { type: Boolean, required: true },
-    workAppropriate: { type: Boolean, required: false }
+    waterproof: { type: Boolean },
+    workAppropriate: { type: Boolean }
   },
   { timestamps: true }
 )

--- a/api/src/models/Outfit.js
+++ b/api/src/models/Outfit.js
@@ -2,11 +2,12 @@ import mongoose from "mongoose"
 
 const OutfitSchema = new mongoose.Schema(
   {
-    imageUrl: { type: String, required: true },
-    occasion: { type: String, required: true },
-    weather: { type: String, required: true },
-    favorite: { type: Boolean, required: false },
-    items: [{ type: mongoose.Schema.Types.ObjectId, ref: "Clothing" }]
+    title: { type: String, required: true },
+    items: [{ type: mongoose.Schema.Types.ObjectId, ref: "Clothing" }],
+    imageUrl: { type: String },
+    occasion: { type: String },
+    weather: { type: String },
+    favorite: { type: Boolean, default: false }
   },
   { timestamps: true }
 )

--- a/api/src/models/Type.js
+++ b/api/src/models/Type.js
@@ -2,12 +2,11 @@ import mongoose from "mongoose"
 
 const TypeSchema = new mongoose.Schema(
   {
-    type: { type: String, required: true },
-    subtypes: [{ type: String, required: true }],
-    drawer: { type: String, required: true },
-    sufficient: { type: Boolean, required: true },
-    necessity: { type: Number, required: false, min: 1, max: 3 },
-    items: [{ type: mongoose.Schema.Types.ObjectId, ref: "Clothing" }]
+    name: { type: String, required: true, unique: true },
+    subtypes: [{ type: String }],
+    drawer: { type: String },
+    sufficient: { type: Boolean, default: false },
+    necessity: { type: Number, default: 0 }
   },
   { timestamps: true }
 )


### PR DESCRIPTION
## What I Did

- Refactor Clothing to reference Type by ObjectId
- Remove requirements on most property fields of Clothing schema
- Add seed-types, seed-clothes, seed-outfits (map-based, one-query lookups)

## Why

Seed documents; confirm working refs between related models