### PR TITLE
feat(detail-pages): add ClothingDetailPage and OutfitDetailPage

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,9 +1,10 @@
 import { Route, Routes } from "react-router-dom"
 import HomePage from "./pages/HomePage"
+import Layout from "./components/Layout"
 import ClothesPage from "./pages/ClothesPage"
 import OutfitsPage from "./pages/OutfitsPage"
 import TypesPage from "./pages/TypesPage"
-import Layout from "./components/Layout"
+import ClothingDetailPage from "./pages/ClothingDetailPage"
 
 export default function App() {
   return (
@@ -13,9 +14,9 @@ export default function App() {
         <Route path="/clothes" element={<ClothesPage />} />
         <Route path="/outfits" element={<OutfitsPage />} />
         <Route path="/types" element={<TypesPage />} />
+        <Route path="/clothes/:id" element={<ClothingDetailPage />} />
       </Route>
-      {/* 404 */}
-      <Route path="*" element={<div style={{ padding: 24 }}>Not found</div>} />
+      <Route path="*" element={<div>Not found</div>} />
     </Routes>
   )
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,6 +5,7 @@ import ClothesPage from "./pages/ClothesPage"
 import OutfitsPage from "./pages/OutfitsPage"
 import TypesPage from "./pages/TypesPage"
 import ClothingDetailPage from "./pages/ClothingDetailPage"
+import OutfitDetailPage from "./pages/OutfitDetailPage"
 
 export default function App() {
   return (
@@ -15,6 +16,7 @@ export default function App() {
         <Route path="/outfits" element={<OutfitsPage />} />
         <Route path="/types" element={<TypesPage />} />
         <Route path="/clothes/:id" element={<ClothingDetailPage />} />
+        <Route path="/outfits/:id" element={<OutfitDetailPage />} />
       </Route>
       <Route path="*" element={<div>Not found</div>} />
     </Routes>

--- a/client/src/hooks/useClothes.jsx
+++ b/client/src/hooks/useClothes.jsx
@@ -9,3 +9,12 @@ export function useClothes() {
     select: (data) => data.map(normalizeClothing)
   })
 }
+
+export function useClothing(id) {
+  return useQuery({
+    queryKey: ["clothing", id],
+    queryFn: () => api.getClothing(id),
+    enabled: !!id,
+    select: normalizeClothing
+  })
+}

--- a/client/src/pages/ClothesPage.jsx
+++ b/client/src/pages/ClothesPage.jsx
@@ -1,7 +1,8 @@
-import { useClothes } from "../hooks/useClothes"
+import { Link } from "react-router-dom"
 import ItemsList from "../components/ItemsList"
 import ClothingItem from "../components/ClothingItem"
 import classes from "./ClothesPage.module.scss"
+import { useClothes } from "../hooks/useClothes"
 
 export default function ClothesPage() {
   const { data: clothes = [], isLoading, error } = useClothes()
@@ -12,11 +13,13 @@ export default function ClothesPage() {
   return (
     <main>
       <div className={classes.container}>
-        <h2>Clothes Page</h2>
+        <h2>Clothes</h2>
         <ItemsList
           items={clothes}
           renderItem={(clothing) => (
-            <ClothingItem clothing={clothing} variant="c" />
+            <Link to={`/clothes/${clothing.id || clothing._id}`}>
+              <ClothingItem clothing={clothing} variant="c" />
+            </Link>
           )}
         />
       </div>

--- a/client/src/pages/ClothingDetailPage.jsx
+++ b/client/src/pages/ClothingDetailPage.jsx
@@ -1,0 +1,183 @@
+import { useMemo, useState, useEffect, useCallback } from "react"
+import { useNavigate, useParams } from "react-router-dom"
+import { useClothing } from "../hooks/useClothes"
+
+function StarRating({ label, value, onChange }) {
+  return (
+    <div className="rating">
+      <p>
+        <strong>{label}:</strong>
+      </p>
+      <div className="stars" role="radiogroup" aria-label={`${label} rating`}>
+        {[1, 2, 3, 4, 5].map((n) => (
+          <button
+            key={n}
+            type="button"
+            role="radio"
+            aria-checked={value === n}
+            onClick={() => onChange(n)}
+            className={`star ${n <= value ? "is-active" : ""}`}
+            title={`${label} ${n} star${n > 1 ? "s" : ""}`}
+          >
+            {/* TODO: create StarRating component */}
+            {n <= value ? "★" : "☆"}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default function ClothingDetailPage() {
+  const navigate = useNavigate()
+  const { id } = useParams()
+  const { data: clothing, isLoading, error } = useClothing(id)
+
+  const storageKey = useMemo(() => `ratings:clothing:${id}`, [id])
+
+  const [ratings, setRatings] = useState(() => {
+    try {
+      const saved = localStorage.getItem(storageKey)
+      if (saved) return JSON.parse(saved)
+    } catch {}
+    return { comfort: 0, confidence: 0, warmth: 0 }
+  })
+
+  useEffect(() => {
+    if (!clothing) return
+    const saved = localStorage.getItem(storageKey)
+    if (!saved && clothing.ratings) {
+      const seeded = {
+        comfort: clothing.ratings.comfort ?? 0,
+        confidence: clothing.ratings.confidence ?? 0,
+        warmth: clothing.ratings.warmth ?? 0
+      }
+      setRatings(seeded)
+      localStorage.setItem(storageKey, JSON.stringify(seeded))
+    }
+  }, [clothing, storageKey])
+
+  useEffect(() => {
+    localStorage.setItem(storageKey, JSON.stringify(ratings))
+  }, [ratings, storageKey])
+
+  const setRating = useCallback(
+    (key, val) => setRatings((r) => ({ ...r, [key]: val })),
+    []
+  )
+
+  const handleBack = () => navigate(-1)
+  const handleEdit = () => {
+    // TODO: route to edit form / open modal
+    console.log("Edit clicked", id)
+  }
+  const handleDelete = async () => {
+    // TODO: await api.deleteClothing(id); navigate("/clothes")
+    console.log("Delete clicked", id)
+  }
+
+  if (isLoading)
+    return (
+      <main className="container">
+        <p>loading…</p>
+      </main>
+    )
+  if (error)
+    return (
+      <main className="container">
+        <p>error: {error.message}</p>
+      </main>
+    )
+  if (!clothing)
+    return (
+      <main className="container">
+        <p>not found</p>
+      </main>
+    )
+
+  const typeName =
+    clothing.type?.name ??
+    clothing.typeName ??
+    (typeof clothing.type === "string" ? clothing.type : "Unknown")
+
+  const colorsText = Array.isArray(clothing.colors)
+    ? clothing.colors.join(", ")
+    : clothing.colors || "Unknown"
+
+  return (
+    <main id="clothing-detail-section">
+      <div className="container">
+        <h2 className="item-name">{clothing.name}</h2>
+
+        <div className="clothing-details">
+          <div className="image-container">
+            <img
+              src={clothing.imageUrl || "/placeholder-img.jpg"}
+              alt={clothing.name || "Clothing item"}
+              className="clothing-image"
+            />
+          </div>
+
+          <div className="details-container">
+            <div className="details-info">
+              <div>
+                <p className="value">{typeName || "Unknown"}</p>
+                <p className="label">TYPE</p>
+              </div>
+              <div>
+                <p className="value">{clothing.subtype || "Unknown"}</p>
+                <p className="label">STYLE</p>
+              </div>
+              <div>
+                <p className="value">{colorsText}</p>
+                <p className="label">COLOR</p>
+              </div>
+              <div>
+                <p className="value">{clothing.size || "Unknown"}</p>
+                <p className="label">SIZE</p>
+              </div>
+            </div>
+
+            <div className="ratings">
+              <StarRating
+                label="Comfort"
+                value={ratings.comfort}
+                onChange={(v) => setRating("comfort", v)}
+              />
+              <StarRating
+                label="Confidence"
+                value={ratings.confidence}
+                onChange={(v) => setRating("confidence", v)}
+              />
+              <StarRating
+                label="Warmth"
+                value={ratings.warmth}
+                onChange={(v) => setRating("warmth", v)}
+              />
+            </div>
+
+            <div className="actions">
+              <button type="button" className="btn" onClick={handleBack}>
+                Go back
+              </button>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={handleEdit}
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                className="btn btn-danger"
+                onClick={handleDelete}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/client/src/pages/OutfitDetailPage.jsx
+++ b/client/src/pages/OutfitDetailPage.jsx
@@ -1,0 +1,210 @@
+import { useParams, useNavigate, Link } from "react-router-dom"
+import { useOutfit } from "../hooks/useOutfit"
+import { useMemo } from "react"
+
+function FavoriteHeart({ isFav }) {
+  return (
+    <span
+      aria-label={isFav ? "favorite" : "not favorite"}
+      title={isFav ? "Favorite" : "Not favorite"}
+      style={{ fontSize: 24, lineHeight: 1 }}
+    >
+      {/* TODO: create FavoriteHeart component */}
+      {isFav ? "❤️" : "🤍"}
+    </span>
+  )
+}
+
+export default function OutfitDetailPage() {
+  const navigate = useNavigate()
+  const { id } = useParams()
+  const { data: outfit, isLoading, error } = useOutfit(id)
+
+  const items = useMemo(() => {
+    return Array.isArray(outfit?.items)
+      ? outfit.items.map((it) => {
+          const isObj = it && typeof it === "object"
+          return {
+            id: isObj ? it.id || it._id : String(it),
+            name: isObj ? it.name ?? "" : "",
+            imageUrl: isObj ? it.imageUrl ?? "" : ""
+          }
+        })
+      : []
+  }, [outfit])
+
+  const handleBack = () => navigate(-1)
+  const handleEdit = () => {
+    // TODO: route to edit form / open modal
+    console.log("Edit outfit", id)
+  }
+  const handleDelete = () => {
+    // TODO: await api.deleteOutfit(id); navigate("/outfits")
+    console.log("Delete outfit", id)
+  }
+
+  if (isLoading)
+    return (
+      <main className="container">
+        <p>loading…</p>
+      </main>
+    )
+  if (error)
+    return (
+      <main className="container">
+        <p>error: {error.message}</p>
+      </main>
+    )
+  if (!outfit)
+    return (
+      <main className="container">
+        <p>not found</p>
+      </main>
+    )
+
+  const cover = outfit.imageUrl || "/placeholder-img.jpg"
+
+  return (
+    <main id="outfit-detail-section">
+      <div className="container">
+        <header
+          className="outfit-header"
+          style={{
+            display: "flex",
+            gap: 16,
+            alignItems: "center",
+            justifyContent: "space-between"
+          }}
+        >
+          <h2 style={{ margin: 0 }}>{outfit.title}</h2>
+          <FavoriteHeart isFav={!!outfit.favorite} />
+        </header>
+
+        <div
+          className="outfit-details"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "320px 1fr",
+            gap: 24,
+            alignItems: "start",
+            marginTop: 16
+          }}
+        >
+          <div className="image-container">
+            <img
+              src={cover}
+              alt={outfit.title}
+              className="outfit-image"
+              style={{
+                width: "100%",
+                height: "auto",
+                borderRadius: 12,
+                objectFit: "cover"
+              }}
+            />
+          </div>
+
+          <div
+            className="details-container"
+            style={{ display: "grid", gap: 16 }}
+          >
+            <div
+              className="meta"
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+                gap: 12
+              }}
+            >
+              <div>
+                <p className="value">{outfit.occasion || "—"}</p>
+                <p className="label">OCCASION</p>
+              </div>
+              <div>
+                <p className="value">{outfit.weather || "—"}</p>
+                <p className="label">WEATHER</p>
+              </div>
+              <div>
+                <p className="value">{items.length}</p>
+                <p className="label">ITEMS</p>
+              </div>
+            </div>
+
+            <section>
+              <h3 style={{ margin: "8px 0 12px" }}>Items in this outfit</h3>
+              <div
+                className="outfit-items-grid"
+                style={{
+                  display: "grid",
+                  gap: 12,
+                  gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))"
+                }}
+              >
+                {items.map((c) => (
+                  <Link
+                    key={c.id}
+                    to={`/clothes/${c.id}`}
+                    className="outfit-item-card"
+                    style={{
+                      display: "grid",
+                      gap: 8,
+                      textDecoration: "none"
+                    }}
+                  >
+                    <div
+                      className="thumb"
+                      style={{
+                        width: "100%",
+                        aspectRatio: "1 / 1",
+                        overflow: "hidden",
+                        borderRadius: 10,
+                        background: "#f3f3f3",
+                        display: "grid",
+                        placeItems: "center"
+                      }}
+                    >
+                      <img
+                        src={c.imageUrl || "/placeholder-img.jpg"}
+                        alt={c.name || "Clothing item"}
+                        style={{
+                          width: "100%",
+                          height: "100%",
+                          objectFit: "cover"
+                        }}
+                      />
+                    </div>
+                    <span style={{ color: "inherit" }}>{c.name || "—"}</span>
+                  </Link>
+                ))}
+                {items.length === 0 && <p>No items yet.</p>}
+              </div>
+            </section>
+
+            <div
+              className="actions"
+              style={{ display: "flex", gap: 8, marginTop: 8 }}
+            >
+              <button type="button" className="btn" onClick={handleBack}>
+                Go back
+              </button>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={handleEdit}
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                className="btn btn-danger"
+                onClick={handleDelete}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/client/src/pages/OutfitsPage.jsx
+++ b/client/src/pages/OutfitsPage.jsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom"
 import ItemsList from "../components/ItemsList"
 import OutfitItem from "../components/OutfitItem"
 import { useOutfits } from "../hooks/useOutfit"
@@ -8,12 +9,16 @@ export default function OutfitsPage() {
   if (error) return <p>error: {error.message}</p>
 
   return (
-    <main id="outfits-section">
+    <main>
       <div className="container">
         <h2>My Outfits</h2>
         <ItemsList
           items={outfits}
-          renderItem={(outfit) => <OutfitItem outfit={outfit} variant="o" />}
+          renderItem={(outfit) => (
+            <Link to={`/outfits/${outfit.id || outfit._id}`}>
+              <OutfitItem outfit={outfit} variant="o" />
+            </Link>
+          )}
         />
       </div>
     </main>


### PR DESCRIPTION
## PR: Introduce detail pages for clothing items and outfits

## Changes Included
### ClothingDetailPage
- New route to App.jsx: /clothes/:id
- Displays descriptive info from several properties
- Added locally-stored only star ratings for comfort, confidence, and warmth, per item
- Image display with fallback placeholder
- Added "Go Back", "Edit", and "Delete" buttons (CRUD to be wired later)

### OutfitDetailPage
- New route to App.jsx: outfits/:id
- Displays descriptive info from several properties
- Image display with fallback placeholder
- Renders each linked clothing item with thumbnail + link to its respective ClothingDetailPage
- Added "Go Back", "Edit", and "Delete" buttons (CRUD to be wired later as well)